### PR TITLE
Jsdoc demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /build
 /release-builds
 /www
+/docs-build
 
 npm-debug.log*
 yarn-debug.log*

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "includePattern": ".+\\.js$"
+  }
+}

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,5 +1,15 @@
 {
   "source": {
     "includePattern": ".+\\.js$"
+  },
+  "plugins": ["node_modules/jsdoc-babel"],
+  "babel": {
+    // Just transform the things that jsdoc can't parse
+    "plugins": [
+      "transform-class-properties",
+      "transform-react-jsx",
+      "transform-object-rest-spread"
+    ],
+    "babelrc": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "electron-packager": "^8.5.2",
     "electron-winstaller": "^2.5.2",
     "icon-gen": "^1.0.7",
-    "jsdoc": "^3.4.3"
+    "jsdoc": "^3.4.3",
+    "jsdoc-babel": "^0.3.0"
   },
   "dependencies": {
     "@mars/heroku-js-runtime-env": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build && cp -r ./build/* ./www",
     "test": "react-scripts test --env=jsdom",
+    "build-docs": "jsdoc src -r -d docs-build -c ./jsdoc.conf.json --verbose",
     "eject": "react-scripts eject",
     "electron": "electron .",
     "generate-icons": "node generate-app-icons.js",
@@ -30,7 +31,8 @@
     "electron-installer-dmg": "^0.2.0",
     "electron-packager": "^8.5.2",
     "electron-winstaller": "^2.5.2",
-    "icon-gen": "^1.0.7"
+    "icon-gen": "^1.0.7",
+    "jsdoc": "^3.4.3"
   },
   "dependencies": {
     "@mars/heroku-js-runtime-env": "^3.0.0",

--- a/src/containers/ProtocolWrapper.js
+++ b/src/containers/ProtocolWrapper.js
@@ -7,7 +7,17 @@ import { actionCreators as protocolActions } from '../ducks/modules/protocol';
 import { ProtocolStage } from '../containers';
 import { Button } from 'semantic-ui-react';
 
+/**
+ * Wraps protocols
+ *
+ * @extends Component
+ */
 class ProtocolWrapper extends Component {
+  /**
+   * Creates an instance of ProtocolWrapper.
+   * @param {any} props
+   *
+   */
   constructor(props) {
     super(props);
     this.state = {
@@ -15,6 +25,9 @@ class ProtocolWrapper extends Component {
     }
   }
 
+  /**
+   * Called when the component is about to be mounted to the DOM
+   */
   componentWillMount() {
     if (!this.props.protocol.protocolLoaded) {
       this.props.loadProtocol()

--- a/src/utils/ProtocolService.js
+++ b/src/utils/ProtocolService.js
@@ -1,8 +1,8 @@
 /**
  * Validates protocol data.
  *
- * @export
- * @class ProtocolService
+ * @extends Component
+ * @module ProtocolService
  */
 export default class ProtocolService {
   constructor() {
@@ -16,7 +16,6 @@ export default class ProtocolService {
    * @param {string} formVarStr - Form variable string
    * @returns {string} Sanitized string
    *
-   * @memberOf ProtocolService
    */
   evaluateSkipLogic(cond, formVarStr) {
     if (typeof formVarStr !== 'string') {

--- a/src/utils/ProtocolService.js
+++ b/src/utils/ProtocolService.js
@@ -1,8 +1,23 @@
+/**
+ * Validates protocol data.
+ *
+ * @export
+ * @class ProtocolService
+ */
 export default class ProtocolService {
   constructor() {
     this.protocol = {}
   }
 
+  /**
+   * Evaluates skip logic
+   *
+   * @param {string} cond - Condition
+   * @param {string} formVarStr - Form variable string
+   * @returns {string} Sanitized string
+   *
+   * @memberOf ProtocolService
+   */
   evaluateSkipLogic(cond, formVarStr) {
     if (typeof formVarStr !== 'string') {
       return;


### PR DESCRIPTION
**Do not merge**

Demo of generating API docs from JSDoc annotations. This uses the `jsdoc` tool to render a default HTML template into `docs-build/`. Other tools can use the same annotations with minimal modification, but `jsdoc` is among the most widely used.

At this point, the important thing is less the actual rendered output, but to get in the habit of adding annotations, especially to functions and classes that will be user-facing.

Feel free to close this PR, I'll keep this branch around for reference.