### PR TITLE
API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /release-builds
 /www
 /.idea
+/docs-build
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository assumes that `npm` is installed. If you don't have it installed,
 |`start`|Serves your app at `localhost:3000`.|
 |`build`|Compiles assets and prepares app for production in the /build directory.|
 |`test`|Runs testing suite.|
-|`eject`|Ejects settings within React Scripts library.|
+|`build-docs`|Builds HTML API docs into the docs-build directory.|
 |`electron`|Runs the current code in electron, for testing.|
 |`generate-icons`|Uses icon-gen package to generate iconsets and icon files for OSX and Windows.|
 |`package-mac`|Uses electron-packager to package an OSX release.|

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "includePattern": ".+\\.js$"
+  }
+}

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,5 +1,15 @@
 {
   "source": {
     "includePattern": ".+\\.js$"
+  },
+  "plugins": ["node_modules/jsdoc-babel"],
+  "babel": {
+    // Just transform the things that jsdoc can't parse
+    "plugins": [
+      "transform-class-properties",
+      "transform-react-jsx",
+      "transform-object-rest-spread"
+    ],
+    "babelrc": false
   }
 }

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -4,7 +4,6 @@
   },
   "plugins": ["node_modules/jsdoc-babel"],
   "babel": {
-    // Just transform the things that jsdoc can't parse
     "plugins": [
       "transform-class-properties",
       "transform-react-jsx",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "icon-gen": "^1.0.7",
     "jest": "18.1.0",
     "jsdoc": "^3.4.3"
+    "jsdoc-babel": "^0.3.0"
     "json-loader": "0.5.4",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js && cp -r ./build/* ./www",
     "test": "node scripts/test.js --env=jsdom",
+    "build-docs": "jsdoc src -r -d docs-build -c ./jsdoc.conf.json --verbose",
     "electron": "electron .",
     "generate-icons": "node generate-app-icons.js",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --icon=assets/icons/round/round.icns --prune=true --out=release-builds --version-string.CompanyName=\"Complex Data Collective\" --version-string.FileDescription=CE --version-string.ProductName=\"Network Canvas\" --version-string.ProductVersion=\"4.0.0\" --ignore=platforms --ignore=hooks --ignore=assets --ignore=www --ignore=build --ignore=plugins",
@@ -60,6 +61,7 @@
     "http-proxy-middleware": "0.17.3",
     "icon-gen": "^1.0.7",
     "jest": "18.1.0",
+    "jsdoc": "^3.4.3"
     "json-loader": "0.5.4",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "http-proxy-middleware": "0.17.3",
     "icon-gen": "^1.0.7",
     "jest": "18.1.0",
-    "jsdoc": "^3.4.3"
-    "jsdoc-babel": "^0.3.0"
+    "jsdoc": "^3.4.3",
+    "jsdoc-babel": "^0.3.0",
     "json-loader": "0.5.4",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",

--- a/src/utils/ProtocolService.js
+++ b/src/utils/ProtocolService.js
@@ -1,8 +1,8 @@
 /**
  * Validates protocol data.
  *
- * @export
- * @class ProtocolService
+ * @extends Component
+ * @module ProtocolService
  */
 export default class ProtocolService {
   constructor() {
@@ -16,7 +16,6 @@ export default class ProtocolService {
    * @param {string} formVarStr - Form variable string
    * @returns {string} Sanitized string
    *
-   * @memberOf ProtocolService
    */
   evaluateSkipLogic(cond, formVarStr) {
     if (typeof formVarStr !== 'string') {

--- a/src/utils/ProtocolService.js
+++ b/src/utils/ProtocolService.js
@@ -1,8 +1,23 @@
+/**
+ * Validates protocol data.
+ *
+ * @export
+ * @class ProtocolService
+ */
 export default class ProtocolService {
   constructor() {
     this.protocol = {}
   }
 
+  /**
+   * Evaluates skip logic
+   *
+   * @param {string} cond - Condition
+   * @param {string} formVarStr - Form variable string
+   * @returns {string} Sanitized string
+   *
+   * @memberOf ProtocolService
+   */
   evaluateSkipLogic(cond, formVarStr) {
     if (typeof formVarStr !== 'string') {
       return;


### PR DESCRIPTION
Adds a task to build HTML API docs based on jsdoc source annotations. Any class or method with a non-empty doc comment (`/** description */`) should be visible in the generated docs.