### PR TITLE
Feature/droppable [wip]

### DIFF
--- a/src/components/Elements/InteractiveNodeList.js
+++ b/src/components/Elements/InteractiveNodeList.js
@@ -1,15 +1,38 @@
 import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import Draggable from 'react-draggable';
 import Touch from 'react-hammerjs';
-import _ from 'lodash';
+import _, { filter } from 'lodash';
 
 import { Node } from '../../components/Elements';
 
+import { actionCreators as droppableActions } from '../../ducks/modules/droppable';
+
 class InteractiveNodeList extends Component {
+
+  dropped = (event) => {
+    const wrap = document.getElementById('page-wrap');
+    const y = event.y + wrap.scrollTop;
+    const x = event.x;
+    this.props.updateZone({
+      name: 'preview',
+      width: 100,
+      height: 100,
+      top: y,
+      left: x,
+    })
+
+    // const hits = filter(this.props.zones, (zone) => {
+    //   return x > zone.left && x < zone.left + zone.width && y > zone.top && y < zone.top + zone.height
+    // });
+    //
+    // console.log(this.props.zones, {x, y});
+  }
 
   draggableNode = (node, index) => {
     return (
-      <Draggable key={ index } position={ { x: 0, y: 0 } } onStop={ () => this.props.handleDragNode(node) }>
+      <Draggable key={ index } position={ { x: 0, y: 0 } } onStop={ this.dropped } >
         <div>
           <Node { ...node } label={ `${node.nickname}` } />
         </div>
@@ -56,4 +79,16 @@ class InteractiveNodeList extends Component {
   }
 }
 
-export default InteractiveNodeList;
+function mapStateToProps(state) {
+  return {
+    zones: state.droppable.zones,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    updateZone: bindActionCreators(droppableActions.updateZone, dispatch)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(InteractiveNodeList);

--- a/src/components/Elements/InteractiveNodeList.js
+++ b/src/components/Elements/InteractiveNodeList.js
@@ -7,8 +7,8 @@ import Draggable from '../../containers/Elements/Draggable';
 
 class InteractiveNodeList extends Component {
 
-  handleDropped = (hits) => {
-    console.log('dropped', hits);
+  handleDropped = (node, hits) => {
+    console.log('dropped', node, hits);
   }
 
   draggableNode = (node, index) => {

--- a/src/components/Elements/InteractiveNodeList.js
+++ b/src/components/Elements/InteractiveNodeList.js
@@ -1,38 +1,19 @@
 import React, { Component } from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import Draggable from 'react-draggable';
 import Touch from 'react-hammerjs';
-import _, { filter } from 'lodash';
+import _ from 'lodash';
 
 import { Node } from '../../components/Elements';
-
-import { actionCreators as droppableActions } from '../../ducks/modules/droppable';
+import Draggable from '../../containers/Elements/Draggable';
 
 class InteractiveNodeList extends Component {
 
-  dropped = (event) => {
-    const wrap = document.getElementById('page-wrap');
-    const y = event.y + wrap.scrollTop;
-    const x = event.x;
-    this.props.updateZone({
-      name: 'preview',
-      width: 100,
-      height: 100,
-      top: y,
-      left: x,
-    })
-
-    // const hits = filter(this.props.zones, (zone) => {
-    //   return x > zone.left && x < zone.left + zone.width && y > zone.top && y < zone.top + zone.height
-    // });
-    //
-    // console.log(this.props.zones, {x, y});
+  handleDropped = (hits) => {
+    console.log('dropped', hits);
   }
 
   draggableNode = (node, index) => {
     return (
-      <Draggable key={ index } position={ { x: 0, y: 0 } } onStop={ this.dropped } >
+      <Draggable key={ index } onDropped={ (hits) => { this.handleDropped(node, hits) } } >
         <div>
           <Node { ...node } label={ `${node.nickname}` } />
         </div>
@@ -79,16 +60,4 @@ class InteractiveNodeList extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    zones: state.droppable.zones,
-  }
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    updateZone: bindActionCreators(droppableActions.updateZone, dispatch)
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(InteractiveNodeList);
+export default InteractiveNodeList;

--- a/src/components/Elements/NodeList.js
+++ b/src/components/Elements/NodeList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Node } from '../Elements';
+import Droppable from '../../containers/Elements/Droppable';
 
 class NodeList extends Component {
   render() {
@@ -10,12 +11,14 @@ class NodeList extends Component {
     } = this.props;
 
     return (
-      <div className='node-list'>
-        { nodes.map((node, index) => {
-          const label = `${node.nickname}`;
-          return <Node key={ index } label={ label } />;
-        }) }
-      </div>
+      <Droppable name="nodelist">
+        <div className='node-list'>
+          { nodes.map((node, index) => {
+            const label = `${node.nickname}`;
+            return <Node key={ index } label={ label } />;
+          }) }
+        </div>
+      </Droppable>
     );
   }
 }

--- a/src/containers/Elements/Draggable.js
+++ b/src/containers/Elements/Draggable.js
@@ -78,12 +78,12 @@ class Draggable extends Component {
   }
 
   getPosition = () => {
-    const element = ReactDOM.findDOMNode(this);
+    const element = ReactDOM.findDOMNode(this).firstChild;
     const boundingClientRect = getAbsoluteBoundingRect(element);
 
     return {
-      y: boundingClientRect.top,
-      x: boundingClientRect.left,
+      y: boundingClientRect.top + boundingClientRect.height * 0.5,
+      x: boundingClientRect.left + boundingClientRect.width * 0.5,
     }
   }
 
@@ -94,25 +94,34 @@ class Draggable extends Component {
       startPosition
     });
 
+    this.props.updateZone({
+      name: 'preview',
+      width: 16,
+      height: 16,
+      y: startPosition.y - 8,
+      x: startPosition.x - 8,
+    })
+
   }
 
   onStop = (event, draggableData) => {
     const { startPosition } = this.state;
 
     const dropped = {
-      top: draggableData.y + startPosition.y,
-      left: draggableData.x + startPosition.x,
+      y: draggableData.y + startPosition.y,
+      x: draggableData.x + startPosition.x,
     };
 
     this.props.updateZone({
       name: 'preview',
-      width: 100,
-      height: 100,
-      ...dropped
+      width: 16,
+      height: 16,
+      y: dropped.y - 8,
+      x: dropped.x - 8,
     })
 
     const hits = filter(this.props.zones, (zone) => {
-      return dropped.left > zone.left && dropped.left < zone.left + zone.width && dropped.top > zone.top && dropped.top < zone.top + zone.height
+      return dropped.x > zone.x && dropped.x < zone.x + zone.width && dropped.y > zone.y && dropped.y < zone.y + zone.height
     });
 
     if (hits.length > 0) {

--- a/src/containers/Elements/Draggable.js
+++ b/src/containers/Elements/Draggable.js
@@ -66,13 +66,42 @@ function getAbsoluteBoundingRect(el) {
 
 class Draggable extends Component {
 
-  onStop = (event) => {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      startPosition: {
+        y: 0,
+        x: 0,
+      }
+    };
+  }
+
+  getPosition = () => {
     const element = ReactDOM.findDOMNode(this);
-    const boundingClientRect = getAbsoluteBoundingRect(element); //element.getBoundingClientRect();
+    const boundingClientRect = getAbsoluteBoundingRect(element);
+
+    return {
+      y: boundingClientRect.top,
+      x: boundingClientRect.left,
+    }
+  }
+
+  onStart = () => {
+    const startPosition = this.getPosition();
+
+    this.setState({
+      startPosition
+    });
+
+  }
+
+  onStop = (event, draggableData) => {
+    const { startPosition } = this.state;
 
     const dropped = {
-      top: event.offsetY + boundingClientRect.top,
-      left: event.offsetX + boundingClientRect.left,
+      top: draggableData.y + startPosition.y,
+      left: draggableData.x + startPosition.x,
     };
 
     this.props.updateZone({
@@ -94,7 +123,7 @@ class Draggable extends Component {
 
   render() {
     return (
-      <ReactDraggable position={ { x: 0, y: 0 } } onStop={ this.onStop } >
+      <ReactDraggable position={ { x: 0, y: 0 } } onStart={ this.onStart } onStop={ this.onStop } >
         { this.props.children }
       </ReactDraggable>
     );

--- a/src/containers/Elements/Droppable.js
+++ b/src/containers/Elements/Droppable.js
@@ -4,63 +4,9 @@ import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
 import { throttle } from 'lodash';
 
+import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
+
 import { actionCreators as droppableActions } from '../../ducks/modules/droppable';
-
-/**
-https://gist.github.com/rgrove/5463265
-
-Returns a bounding rect for _el_ with absolute coordinates corrected for
-scroll positions.
-
-The native `getBoundingClientRect()` returns coordinates for an element's
-visual position relative to the top left of the viewport, so if the element
-is part of a scrollable region that has been scrolled, its coordinates will
-be different than if the region hadn't been scrolled.
-
-This method corrects for scroll offsets all the way up the node tree, so the
-returned bounding rect will represent an absolute position on a virtual
-canvas, regardless of scrolling.
-
-@method getAbsoluteBoundingRect
-@param {HTMLElement} el HTML element.
-@return {Object} Absolute bounding rect for _el_.
-**/
-
-function getAbsoluteBoundingRect(el) {
-    var doc  = document,
-        win  = window,
-        body = doc.body,
-
-        // pageXOffset and pageYOffset work everywhere except IE <9.
-        offsetX = win.pageXOffset !== undefined ? win.pageXOffset :
-            (doc.documentElement || body.parentNode || body).scrollLeft,
-        offsetY = win.pageYOffset !== undefined ? win.pageYOffset :
-            (doc.documentElement || body.parentNode || body).scrollTop,
-
-        rect = el.getBoundingClientRect();
-
-    if (el !== body) {
-        var parent = el.parentNode;
-
-        // The element's rect will be affected by the scroll positions of
-        // *all* of its scrollable parents, not just the window, so we have
-        // to walk up the tree and collect every scroll offset. Good times.
-        while (parent !== body) {
-            offsetX += parent.scrollLeft;
-            offsetY += parent.scrollTop;
-            parent   = parent.parentNode;
-        }
-    }
-
-    return {
-        bottom: rect.bottom + offsetY,
-        height: rect.height,
-        left  : rect.left + offsetX,
-        right : rect.right + offsetX,
-        top   : rect.top + offsetY,
-        width : rect.width
-    };
-}
 
 class Droppable extends Component {
   constructor(props) {

--- a/src/containers/Elements/Droppable.js
+++ b/src/containers/Elements/Droppable.js
@@ -90,10 +90,8 @@ class Droppable extends Component {
       name: this.props.name,
       width: boundingClientRect.width,
       height: boundingClientRect.height,
-      top: boundingClientRect.top,
-      left: boundingClientRect.left,
-      bottom: boundingClientRect.bottom,
-      right: boundingClientRect.right,
+      y: boundingClientRect.top,
+      x: boundingClientRect.left,
     });
   }
 

--- a/src/containers/Elements/Droppable.js
+++ b/src/containers/Elements/Droppable.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import ReactDOM from 'react-dom';
+import { throttle } from 'lodash';
+
+import { actionCreators as droppableActions } from '../../ducks/modules/droppable';
+
+class Droppable extends Component {
+  constructor(props) {
+    super(props);
+
+    this.updateZone = throttle(this.updateZone, 1000/60);  // 60fps max
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateZone);
+  }
+
+  componentDidMount() {
+    this.updateZone();
+    window.addEventListener('resize', this.updateZone);
+  }
+
+  componentDidUpdate() {
+    this.updateZone();
+  }
+
+  updateZone = () => {
+    const element = ReactDOM.findDOMNode(this);
+    const boundingClientRect = element.getBoundingClientRect();
+
+    this.props.updateZone({
+      name: this.props.name,
+      width: boundingClientRect.width,
+      height: boundingClientRect.height,
+      top: boundingClientRect.top,
+      left: boundingClientRect.left,
+      bottom: boundingClientRect.bottom,
+      right: boundingClientRect.right,
+    });
+  }
+
+  render() {
+    return (
+      <div className='droppable'>
+        { this.props.children }
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    zones: state.droppable.zones,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    updateZone: bindActionCreators(droppableActions.updateZone, dispatch)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Droppable);

--- a/src/containers/Elements/NodeProvider.js
+++ b/src/containers/Elements/NodeProvider.js
@@ -18,6 +18,10 @@ class NodeProvider extends Component {
     }
   }
 
+  handleDropNode = (argv) => {
+    console.log('dropped', argv);
+  }
+
   render() {
     const {
       interaction,
@@ -26,7 +30,7 @@ class NodeProvider extends Component {
     } = this.props;
 
     return (
-      <InteractiveNodeList interaction={ interaction } network={ network } activeNodeAttributes={ activePromptAttributes } handleDragNode={ () => {} } handleSelectNode={ this.handleSelectNode } />
+      <InteractiveNodeList interaction={ interaction } network={ network } activeNodeAttributes={ activePromptAttributes } handleDropNode={ this.handleDropNode } handleSelectNode={ this.handleSelectNode } />
     );
   }
 }

--- a/src/containers/Protocol.js
+++ b/src/containers/Protocol.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { actionCreators as protocolActions } from '../ducks/modules/protocol';
 import Stage from './Stage';
+import Zones from './Zones';
 
 /**
   * Load protocol data, and render a stage
@@ -20,6 +21,7 @@ class Protocol extends Component {
     return (
       <div className='protocol'>
         <Stage />
+        <Zones />
       </div>
     );
   }

--- a/src/containers/Zones.js
+++ b/src/containers/Zones.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class Zones extends Component {
+  render() {
+    return (
+      <div className='zones'>
+        { this.props.zones.map((zone, index) => {
+          const styles = {
+            width: zone.width,
+            height: zone.height,
+            top: zone.top,
+            left: zone.left,
+            position: 'absolute',
+            background: 'rgba(0, 255, 50, 0.5)',
+          };
+          return (<div key={ index } style={ styles }></div>);
+        }) };
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    zones: state.droppable.zones,
+  }
+}
+
+export default connect(mapStateToProps)(Zones);

--- a/src/containers/Zones.js
+++ b/src/containers/Zones.js
@@ -15,7 +15,7 @@ class Zones extends Component {
             background: 'rgba(0, 255, 50, 0.5)',
           };
           return (<div key={ index } style={ styles }></div>);
-        }) };
+        }) }
       </div>
     );
   }

--- a/src/containers/Zones.js
+++ b/src/containers/Zones.js
@@ -12,7 +12,7 @@ class Zones extends Component {
             top: zone.y,
             left: zone.x,
             position: 'absolute',
-            background: 'rgba(0, 255, 50, 0.5)',
+            background: (zone.name === 'preview' ? 'rgba(255, 0, 50, 0.5)' : 'rgba(0, 255, 50, 0.5)'),
           };
           return (<div key={ index } style={ styles }></div>);
         }) }

--- a/src/containers/Zones.js
+++ b/src/containers/Zones.js
@@ -9,8 +9,8 @@ class Zones extends Component {
           const styles = {
             width: zone.width,
             height: zone.height,
-            top: zone.top,
-            left: zone.left,
+            top: zone.y,
+            left: zone.x,
             position: 'absolute',
             background: 'rgba(0, 255, 50, 0.5)',
           };

--- a/src/ducks/modules/droppable.js
+++ b/src/ducks/modules/droppable.js
@@ -1,0 +1,40 @@
+import { reject } from 'lodash';
+
+const UPDATE_ZONE = 'UPDATE_ZONE';
+
+const initialState = {
+  zones: []
+};
+
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+      case UPDATE_ZONE:
+        const zones = [ ...reject(state.zones, ['name', action.zone.name]), action.zone ];
+        return {
+          ...state,
+          zones
+        }
+    default:
+      return state;
+  }
+};
+
+function updateZone(zone) {
+  return {
+    type: UPDATE_ZONE,
+    zone: zone,
+  }
+};
+
+const actionCreators = {
+  updateZone,
+};
+
+const actionTypes = {
+  UPDATE_ZONE,
+};
+
+export {
+  actionCreators,
+  actionTypes,
+};

--- a/src/ducks/modules/rootReducer.js
+++ b/src/ducks/modules/rootReducer.js
@@ -6,6 +6,7 @@ import page from './page';
 import participant from './participant';
 import protocol from './protocol';
 import session from './session';
+import droppable from './droppable';
 
 export default function(persistor) {
   return combineReducers({
@@ -15,5 +16,6 @@ export default function(persistor) {
       participant,
       protocol: protocol(persistor),
       session,
+      droppable,
   })
 };

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -6,3 +6,4 @@
 @import 'interface';
 @import 'protocol';
 @import 'modal';
+@import 'react-draggable';

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -7,4 +7,5 @@
 @import 'protocol';
 @import 'modal';
 @import 'react-draggable';
+@import 'draggable-preview';
 @import 'panel';

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -7,3 +7,4 @@
 @import 'protocol';
 @import 'modal';
 @import 'react-draggable';
+@import 'panel';

--- a/src/styles/components/_draggable-preview.scss
+++ b/src/styles/components/_draggable-preview.scss
@@ -1,0 +1,3 @@
+.draggable-preview {
+  display: inline-block;
+}

--- a/src/styles/components/_menu.scss
+++ b/src/styles/components/_menu.scss
@@ -98,6 +98,7 @@
   overflow: scroll;
   padding: 6rem;
   transition: all $animation-standard-duration $animation-default-easing;
+  position: relative;
 }
 
 #page-wrap.isOpen {

--- a/src/styles/components/_panel.scss
+++ b/src/styles/components/_panel.scss
@@ -1,0 +1,4 @@
+.panel {
+  max-height: 200px;
+  overflow-y: scroll;
+}

--- a/src/styles/components/_react-draggable.scss
+++ b/src/styles/components/_react-draggable.scss
@@ -1,0 +1,2 @@
+.react-draggable {
+}

--- a/src/utils/getAbsoluteBoundingRect.js
+++ b/src/utils/getAbsoluteBoundingRect.js
@@ -1,0 +1,55 @@
+/**
+https://gist.github.com/rgrove/5463265
+
+Returns a bounding rect for _el_ with absolute coordinates corrected for
+scroll positions.
+
+The native `getBoundingClientRect()` returns coordinates for an element's
+visual position relative to the top left of the viewport, so if the element
+is part of a scrollable region that has been scrolled, its coordinates will
+be different than if the region hadn't been scrolled.
+
+This method corrects for scroll offsets all the way up the node tree, so the
+returned bounding rect will represent an absolute position on a virtual
+canvas, regardless of scrolling.
+
+@method getAbsoluteBoundingRect
+@param {HTMLElement} el HTML element.
+@return {Object} Absolute bounding rect for _el_.
+**/
+
+export default function getAbsoluteBoundingRect(el) {
+    var doc  = document,
+        win  = window,
+        body = doc.body,
+
+        // pageXOffset and pageYOffset work everywhere except IE <9.
+        offsetX = win.pageXOffset !== undefined ? win.pageXOffset :
+            (doc.documentElement || body.parentNode || body).scrollLeft,
+        offsetY = win.pageYOffset !== undefined ? win.pageYOffset :
+            (doc.documentElement || body.parentNode || body).scrollTop,
+
+        rect = el.getBoundingClientRect();
+
+    if (el !== body) {
+        var parent = el.parentNode;
+
+        // The element's rect will be affected by the scroll positions of
+        // *all* of its scrollable parents, not just the window, so we have
+        // to walk up the tree and collect every scroll offset. Good times.
+        while (parent !== body) {
+            offsetX += parent.scrollLeft;
+            offsetY += parent.scrollTop;
+            parent   = parent.parentNode;
+        }
+    }
+
+    return {
+        bottom: rect.bottom + offsetY,
+        height: rect.height,
+        left  : rect.left + offsetX,
+        right : rect.right + offsetX,
+        top   : rect.top + offsetY,
+        width : rect.width
+    };
+}


### PR DESCRIPTION
Roughly working demo of drag and drop

- tracks a drop zone (node list), with `<Droppable accepts={ ['node'] } />`
- triggers an event on `<Draggable>`, which can be used to capture drops
- currently console.logs any draggables dropped into drop zones.

next steps:
- test on devices
- make drop zone more accurate?

enhancements:
- could specify types for draggable and droppable, e.g.
  ```jsx
  <Droppable accepts={ ['node'] } />
  <Draggable type='node' />
  ```
- updates zones on window.resize, suggest also just running a slow setInterval for edge cases