### PR TITLE
Feature/droppable clean

### DIFF
--- a/src/components/Elements/DraggableNodeList.js
+++ b/src/components/Elements/DraggableNodeList.js
@@ -1,19 +1,19 @@
 import React, { Component } from 'react';
-import Draggable from 'react-draggable';
+import Draggable from '../../containers/Elements/Draggable';
 import { Node } from '../../components/Elements';
 
 class DraggableNodeList extends Component {
   render() {
     const {
       network,
-      handleDragNode,
+      handleDropNode,
     } = this.props;
 
     return (
       <div class='node-list node-list--draggable'>
         { network.nodes.map((node, index) => {
           return (
-            <Draggable key={ index } position={ { x: 0, y: 0 } } onStop={ () => handleDragNode(node) }>
+            <Draggable key={ index } position={ { x: 0, y: 0 } } onDropped={ (hits) => handleDropNode(node, hits) }>
               <div>
                 <Node { ...node } label={ `${node.nickname}` } />
               </div>

--- a/src/components/Elements/DraggableNodeList.js
+++ b/src/components/Elements/DraggableNodeList.js
@@ -13,7 +13,7 @@ class DraggableNodeList extends Component {
       <div class='node-list node-list--draggable'>
         { network.nodes.map((node, index) => {
           return (
-            <Draggable key={ index } position={ { x: 0, y: 0 } } onDropped={ (hits) => handleDropNode(node, hits) }>
+            <Draggable key={ index } position={ { x: 0, y: 0 } } onDropped={ (hits) => handleDropNode(hits, node) }>
               <div>
                 <Node { ...node } label={ `${node.nickname}` } />
               </div>

--- a/src/components/Elements/NodeList.js
+++ b/src/components/Elements/NodeList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Node } from '../Elements';
+import Droppable from '../../containers/Elements/Droppable';
 
 class NodeList extends Component {
   render() {
@@ -10,12 +11,14 @@ class NodeList extends Component {
     } = this.props;
 
     return (
-      <div className='node-list'>
-        { nodes.map((node, index) => {
-          const label = `${node.nickname}`;
-          return <Node key={ index } label={ label } />;
-        }) }
-      </div>
+      <Droppable name="nodelist">
+        <div className='node-list'>
+          { nodes.map((node, index) => {
+            const label = `${node.nickname}`;
+            return <Node key={ index } label={ label } />;
+          }) }
+        </div>
+      </Droppable>
     );
   }
 }

--- a/src/containers/Elements/Draggable.js
+++ b/src/containers/Elements/Draggable.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { DraggableCore } from 'react-draggable';
+import ReactDOM from 'react-dom';
+import { filter } from 'lodash';
+import DraggablePreview from '../../utils/DraggablePreview';
+
+class Draggable extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      preview: {
+        visible: false,
+      },
+    };
+  }
+
+  componentWillUnmount() {
+    if (this.state.preview.preview) { this.state.preview.preview.cleanup(); }
+  }
+
+  onStart = (_, draggableData) => {
+    const draggablePreview = new DraggablePreview(ReactDOM.findDOMNode(this).firstChild);
+
+    this.setState({
+      preview: {
+        visible: true,
+        preview: draggablePreview,
+      }
+    }, () => {
+      this.state.preview.preview.position(draggableData.x, draggableData.y);
+    });
+  }
+
+  onDrag = (event, draggableData) => {
+    if (!this.state.preview.preview) { return; }
+    this.state.preview.preview.position(draggableData.x, draggableData.y);
+  }
+
+  onStop = (event, draggableData) => {
+    if (this.state.preview.preview) { this.state.preview.preview.cleanup(); }
+
+    this.setState({
+      preview: {
+        visible: false,
+      }
+    });
+
+    const hits = filter(this.props.zones, (zone) => {
+      return draggableData.x > zone.x && draggableData.x < zone.x + zone.width && draggableData.y > zone.y && draggableData.y < zone.y + zone.height
+    });
+
+    if (hits.length > 0) {
+      this.props.onDropped(hits);
+    }
+
+  }
+
+  render() {
+    const opacity = this.state.preview.visible ? { opacity: 0 } : { opacity: 1 };
+
+    return (
+      <DraggableCore position={ { x: 0, y: 0 } } onStart={ this.onStart } onStop={ this.onStop } onDrag={ this.onDrag }>
+        <div style={ opacity }>
+          { this.props.children }
+        </div>
+      </DraggableCore>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    zones: state.droppable.zones,
+  }
+}
+
+export default connect(mapStateToProps)(Draggable);

--- a/src/containers/Elements/Droppable.js
+++ b/src/containers/Elements/Droppable.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import ReactDOM from 'react-dom';
+import { throttle } from 'lodash';
+
+import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
+
+import { actionCreators as droppableActions } from '../../ducks/modules/droppable';
+
+class Droppable extends Component {
+  constructor(props) {
+    super(props);
+
+    this.updateZone = throttle(this.updateZone, 1000/60);  // 60fps max
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateZone);
+  }
+
+  componentDidMount() {
+    this.updateZone();
+    window.addEventListener('resize', this.updateZone);
+  }
+
+  componentDidUpdate() {
+    this.updateZone();
+  }
+
+  updateZone = () => {
+    const element = ReactDOM.findDOMNode(this);
+    const boundingClientRect = getAbsoluteBoundingRect(element); //element.getBoundingClientRect();
+
+    this.props.updateZone({
+      name: this.props.name,
+      width: boundingClientRect.width,
+      height: boundingClientRect.height,
+      y: boundingClientRect.top,
+      x: boundingClientRect.left,
+    });
+  }
+
+  render() {
+    return (
+      <div className='droppable'>
+        { this.props.children }
+      </div>
+    );
+  }
+}
+
+function mapStateToProps() {
+  return {};
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    updateZone: bindActionCreators(droppableActions.updateZone, dispatch)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Droppable);

--- a/src/containers/Elements/NodeProvider.js
+++ b/src/containers/Elements/NodeProvider.js
@@ -18,6 +18,10 @@ class NodeProvider extends Component {
     }
   }
 
+  handleDropNode = (node, hits) => {
+    console.log('dropped', node, hits);
+  }
+
   render() {
     const {
       interaction,
@@ -29,11 +33,10 @@ class NodeProvider extends Component {
       case 'selectable':
         return <SelectableNodeList network={ network } activeNodeAttributes={ activePromptAttributes } handleSelectNode={ this.handleSelectNode } />;
       case 'draggable':
-        return <DraggableNodeList network={ network } activeNodeAttributes={ activePromptAttributes } handleDragNode={ () => {} } />;
+        return <DraggableNodeList network={ network } activeNodeAttributes={ activePromptAttributes } handleDropNode={ this.handleDropNode } />;
       default:
         return <NodeList network={ network } />;
     }
-
   }
 }
 

--- a/src/containers/Elements/NodeProvider.js
+++ b/src/containers/Elements/NodeProvider.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 
 import { actionCreators as networkActions } from '../../ducks/modules/network';
-import { activePromptAttributes } from '../../selectors/session';
+import { activeNodeAttributes, activePromptAttributes } from '../../selectors/session';
 import { filteredDataSource } from '../../selectors/dataSource';
 
 import { NodeList, SelectableNodeList, DraggableNodeList } from '../../components/Elements';
@@ -18,8 +18,8 @@ class NodeProvider extends Component {
     }
   }
 
-  handleDropNode = (node, hits) => {
-    console.log('dropped', node, hits);
+  handleDropNode = (hits, node) => {
+    this.props.addNode({ ...this.props.activeNodeAttributes, ...node });
   }
 
   render() {
@@ -46,6 +46,7 @@ function mapStateToProps(state, ownProps) {
   return {
     network: filteredDataSource(state, ownProps),
     interaction,
+    activeNodeAttributes: activeNodeAttributes(state),
     activePromptAttributes: activePromptAttributes(state),
   }
 }

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { actionCreators as networkActions } from '../../ducks/modules/network';
 import { activeNodeAttributes } from '../../selectors/session';
-import { activeNetwork } from '../../selectors/network';
+import { activePromptNetwork } from '../../selectors/network';
 
 import { PromptSwiper, NodeProviderPanels } from '../../containers/Elements';
 import { NodeList, Modal, Form } from '../../components/Elements';
@@ -49,7 +49,7 @@ class NameGenerator extends Component {
           panels,
         },
       },
-      activeNetwork,
+      activePromptNetwork,
     } = this.props;
 
     return (
@@ -60,7 +60,7 @@ class NameGenerator extends Component {
         <div className='interface__primary'>
           <PromptSwiper prompts={ prompts } />
 
-          <NodeList network={ activeNetwork } />
+          <NodeList network={ activePromptNetwork } />
 
           <button onClick={ this.toggleModal }>
             Add a person
@@ -81,7 +81,7 @@ function mapStateToProps(state) {
     network: state.network,
     protocol: state.protocol,
     activeNodeAttributes: activeNodeAttributes(state),
-    activeNetwork: activeNetwork(state),
+    activePromptNetwork: activePromptNetwork(state),
   }
 }
 

--- a/src/containers/ZonesDebugger.js
+++ b/src/containers/ZonesDebugger.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ZonesDebugger extends Component {
+  render() {
+    return (
+      <div className='zones'>
+        { this.props.zones.map((zone, index) => {
+          const styles = {
+            width: zone.width,
+            height: zone.height,
+            top: zone.y,
+            left: zone.x,
+            position: 'absolute',
+            background: (zone.name === 'highlight' ? 'rgba(255, 0, 50, 0.5)' : 'rgba(0, 255, 50, 0.5)'),
+          };
+          return (<div key={ index } style={ styles }></div>);
+        }) }
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    zones: state.droppable.zones,
+  }
+}
+
+export default connect(mapStateToProps)(ZonesDebugger);

--- a/src/ducks/modules/droppable.js
+++ b/src/ducks/modules/droppable.js
@@ -1,0 +1,40 @@
+import { reject } from 'lodash';
+
+const UPDATE_ZONE = 'UPDATE_ZONE';
+
+const initialState = {
+  zones: []
+};
+
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+      case UPDATE_ZONE:
+        const zones = [ ...reject(state.zones, ['name', action.zone.name]), action.zone ];
+        return {
+          ...state,
+          zones
+        }
+    default:
+      return state;
+  }
+};
+
+function updateZone(zone) {
+  return {
+    type: UPDATE_ZONE,
+    zone: zone,
+  }
+};
+
+const actionCreators = {
+  updateZone,
+};
+
+const actionTypes = {
+  UPDATE_ZONE,
+};
+
+export {
+  actionCreators,
+  actionTypes,
+};

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -16,17 +16,15 @@ const initialState = {
 };
 
 function nextId(nodes) {
-  if (nodes.length == 0) { return 1; }
-  return _.map(nodes, 'id').reduce((memo, id) => { return memo > id ? memo : id }) + 1;
+  return `${Date.now()}_${nodes.length + 1}`;
 }
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case ADD_NODE:
       const id = nextId(state.nodes);
-      const node = { ...action.node, id }
+      const node = { id, ...action.node }  // Provided id can override nextId
       return {
-        // rest parameters - ...state contains array of the rest of values of state (above)
         ...state,
         nodes: [...state.nodes, node]
       }

--- a/src/ducks/modules/rootReducer.js
+++ b/src/ducks/modules/rootReducer.js
@@ -6,6 +6,7 @@ import page from './page';
 import participant from './participant';
 import protocol from './protocol';
 import session from './session';
+import droppable from './droppable';
 
 export default function(persistor) {
   return combineReducers({
@@ -15,5 +16,6 @@ export default function(persistor) {
       participant,
       protocol: protocol(persistor),
       session,
+      droppable,
   })
 };

--- a/src/selectors/dataSource.js
+++ b/src/selectors/dataSource.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect'
 
-import { existingNetwork } from './network'
+import { join, difference } from '../utils/Network'
+import { restOfNetwork, activeStageNetwork } from './network'
 
 const data = state => state.protocol.protocolConfig.data;
 
@@ -17,13 +18,14 @@ const fromSource = createSelector(
 export const dataSource = createSelector(
   source,
   fromSource,
-  existingNetwork,
-  (source, fromSource, existingNetwork) => {
+  restOfNetwork,
+  activeStageNetwork,
+  (source, fromSource, restOfNetwork, activeStageNetwork) => {
     switch (source) {
       case 'existing':
-        return existingNetwork;
+        return restOfNetwork;  // that aren't on this stage, but have the same type
       default:
-        return fromSource;
+        return difference(fromSource, join(restOfNetwork, activeStageNetwork));  // that aren't on this screen.
     }
   }
 );
@@ -32,6 +34,6 @@ export const filteredDataSource = createSelector(
   dataSource,
   filter,
   (dataSource, filter) => {
-    return filter(dataSource)
+    return filter(dataSource);
   }
 );

--- a/src/selectors/network.js
+++ b/src/selectors/network.js
@@ -1,10 +1,20 @@
 import { createSelector } from 'reselect'
-import { diff, nodeIncludesAttributes } from '../utils/Network';
+import { difference, nodeIncludesAttributes } from '../utils/Network';
 import { activeNodeAttributes, activeStageAttributes } from './session';
 
 const network = state => state.network;
 
-export const activeNetwork = createSelector(
+// Filter the network according to current stage AND prompt
+export const activeStageNetwork = createSelector(
+  network,
+  activeStageAttributes,
+  (network, activeStageAttributes) => {
+    return nodeIncludesAttributes(network, activeStageAttributes);
+  }
+)
+
+// Filter the network according to current stage AND prompt
+export const activePromptNetwork = createSelector(
   network,
   activeNodeAttributes,
   (network, activeNodeAttributes) => {
@@ -12,10 +22,13 @@ export const activeNetwork = createSelector(
   }
 )
 
-export const existingNetwork = createSelector(
+// Filter the network:
+// - Node is not from current stage
+// - Node is the same type as current stage
+export const restOfNetwork = createSelector(
   network,
   activeStageAttributes,
   (network, activeStageAttributes) => {
-    return nodeIncludesAttributes(diff(network, nodeIncludesAttributes(network, { stageId: activeStageAttributes.stageId })), { type: activeStageAttributes.type });
+    return nodeIncludesAttributes(difference(network, nodeIncludesAttributes(network, { stageId: activeStageAttributes.stageId })), { type: activeStageAttributes.type });
   }
 )

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -6,3 +6,6 @@
 @import 'interface';
 @import 'protocol';
 @import 'modal';
+@import 'react-draggable';
+@import 'draggable-preview';
+@import 'panel';

--- a/src/styles/components/_draggable-preview.scss
+++ b/src/styles/components/_draggable-preview.scss
@@ -1,0 +1,3 @@
+.draggable-preview {
+  display: inline-block;
+}

--- a/src/styles/components/_menu.scss
+++ b/src/styles/components/_menu.scss
@@ -98,6 +98,7 @@
   overflow: scroll;
   padding: 6rem;
   transition: all $animation-standard-duration $animation-default-easing;
+  position: relative;
 }
 
 #page-wrap.isOpen {

--- a/src/styles/components/_nodeList.scss
+++ b/src/styles/components/_nodeList.scss
@@ -4,4 +4,5 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: flex-start;
+  min-height: 100px;
 }

--- a/src/styles/components/_panel.scss
+++ b/src/styles/components/_panel.scss
@@ -1,0 +1,4 @@
+.panel {
+  max-height: 200px;
+  overflow-y: scroll;
+}

--- a/src/styles/components/_panel.scss
+++ b/src/styles/components/_panel.scss
@@ -1,4 +1,2 @@
 .panel {
-  max-height: 200px;
-  overflow-y: scroll;
 }

--- a/src/styles/components/_react-draggable.scss
+++ b/src/styles/components/_react-draggable.scss
@@ -1,0 +1,2 @@
+.react-draggable {
+}

--- a/src/utils/DraggablePreview.js
+++ b/src/utils/DraggablePreview.js
@@ -1,0 +1,53 @@
+import { throttle } from 'lodash';
+import getAbsoluteBoundingRect from './getAbsoluteBoundingRect';
+
+const getSize = (element) => {
+  const boundingClientRect = getAbsoluteBoundingRect(element);
+
+  return {
+    width: Math.floor(boundingClientRect.width),
+    height: Math.floor(boundingClientRect.height),
+  }
+}
+
+export default class DraggablePreview {
+  constructor(node) {
+    this.position = throttle(this.position, 1000/60);
+
+    this.node = document.createElement('div');
+    this.node.setAttribute('class', 'draggable-preview');
+    this.node.appendChild(node.cloneNode(true));
+
+    this.parent().appendChild(this.node);
+  }
+
+  parent() {
+    return document.getElementById('page-wrap');
+  }
+
+  size() {
+    if (!this.node) { return { width: 0, height: 0 }; }
+    if (!this._size) { this._size = getSize(this.node); }
+    return this._size;
+  }
+
+  center() {
+    if (!this._center) {
+      this._center = {
+        x: Math.floor(this.size().width / 2),
+        y: Math.floor(this.size().height / 2),
+      }
+    }
+    return this._center;
+  }
+
+  position(x, y) {
+    x = x - this.center().x;
+    y = y - this.center().y;
+    this.node.setAttribute('style', `position: absolute; left: 0px; top: 0px; transform: translate(${x}px, ${y}px);`);
+  }
+
+  cleanup() {
+    this.parent().removeChild(this.node);
+  }
+}

--- a/src/utils/Network.js
+++ b/src/utils/Network.js
@@ -1,29 +1,39 @@
-import _ from 'lodash';
+import { filter, differenceBy } from 'lodash';
 
 const nodeIncludesAttributes = (network, attributes) => {
-  const nodes = _.filter(network.nodes, attributes);
+  const nodes = filter(network.nodes, attributes);
 
   return {
+    ...network,  // TODO: filter edge etc.
     nodes
   }
 }
 
-const diff = (source, target) => {
-  const nodes = _.reject(source.nodes, (nodeA) => {
-    return _.findIndex(target.nodes, (nodeB) => { return _.isEqual(nodeA, nodeB); }) !== -1;
-  });
+const difference = (source, target) => {
+  const nodes = differenceBy(source.nodes, target.nodes, 'id');
 
   return {
+    ...source,  // TODO: filter edge etc.
     nodes
+  }
+}
+
+const join = (networkA, networkB) => {
+  return {
+    ...networkA,  // TODO: combine edge etc.
+    edges: [ ...networkA.edges, ...networkB.edges ],
+    nodes: [ ...networkA.nodes, ...networkB.nodes ],
   }
 }
 
 export {
   nodeIncludesAttributes,
-  diff,
+  difference,
+  join,
 };
 
 export default {
   nodeIncludesAttributes,
-  diff,
+  difference,
+  join,
 };

--- a/src/utils/ProtocolService.js
+++ b/src/utils/ProtocolService.js
@@ -40,16 +40,19 @@ export default class ProtocolService {
         "previous": {
           nodes: [
             {
+              id: "previous_1",
               type: "person",
               name: "Fred",
               nickname: "Foo",
             },
             {
+              id: "previous_2",
               type: "person",
               name: "Bob",
               nickname: "Bar",
             },
             {
+              id: "previous_3",
               type: "person",
               name: "Barry",
               nickname: "Baz",

--- a/src/utils/getAbsoluteBoundingRect.js
+++ b/src/utils/getAbsoluteBoundingRect.js
@@ -1,0 +1,55 @@
+/**
+https://gist.github.com/rgrove/5463265
+
+Returns a bounding rect for _el_ with absolute coordinates corrected for
+scroll positions.
+
+The native `getBoundingClientRect()` returns coordinates for an element's
+visual position relative to the top left of the viewport, so if the element
+is part of a scrollable region that has been scrolled, its coordinates will
+be different than if the region hadn't been scrolled.
+
+This method corrects for scroll offsets all the way up the node tree, so the
+returned bounding rect will represent an absolute position on a virtual
+canvas, regardless of scrolling.
+
+@method getAbsoluteBoundingRect
+@param {HTMLElement} el HTML element.
+@return {Object} Absolute bounding rect for _el_.
+**/
+
+export default function getAbsoluteBoundingRect(el) {
+    var doc  = document,
+        win  = window,
+        body = doc.body,
+
+        // pageXOffset and pageYOffset work everywhere except IE <9.
+        offsetX = win.pageXOffset !== undefined ? win.pageXOffset :
+            (doc.documentElement || body.parentNode || body).scrollLeft,
+        offsetY = win.pageYOffset !== undefined ? win.pageYOffset :
+            (doc.documentElement || body.parentNode || body).scrollTop,
+
+        rect = el.getBoundingClientRect();
+
+    if (el !== body) {
+        var parent = el.parentNode;
+
+        // The element's rect will be affected by the scroll positions of
+        // *all* of its scrollable parents, not just the window, so we have
+        // to walk up the tree and collect every scroll offset. Good times.
+        while (parent !== body) {
+            offsetX += parent.scrollLeft;
+            offsetY += parent.scrollTop;
+            parent   = parent.parentNode;
+        }
+    }
+
+    return {
+        bottom: rect.bottom + offsetY,
+        height: rect.height,
+        left  : rect.left + offsetX,
+        right : rect.right + offsetX,
+        top   : rect.top + offsetY,
+        width : rect.width
+    };
+}


### PR DESCRIPTION
Roughly working demo of drag and drop

- tracks a drop zone (node list), with `<Droppable />`
- triggers an event on `<Draggable>`, which can be used to capture drops
- currently console.logs any draggables dropped into drop zones.

enhancements:
- could specify types for draggable and droppable, e.g.
  ```jsx
  <Droppable accepts={ ['node'] } />
  <Draggable type='node' />
  ```
- updates zones on window.resize, suggest also just running a slow setInterval for edge cases